### PR TITLE
Use rattler to install packages

### DIFF
--- a/conda/cli/install.py
+++ b/conda/cli/install.py
@@ -10,6 +10,9 @@ conda.cli.main_remove for the entry points into this module.
 
 from __future__ import annotations
 
+from rattler import install as rattler_install
+from rattler import RepoDataRecord, PackageRecord
+
 import os
 from logging import getLogger
 from os.path import abspath, basename, exists, isdir
@@ -309,8 +312,8 @@ def ensure_update_specs_exist(prefix: str, specs: list[str]):
         if not prefix_data.get(spec.name, None):
             raise PackageNotInstalledError(prefix, spec.name)
 
-
-def install(args, parser, command="install"):
+    
+async def install(args, parser, command="install"):
     """Logic for `conda install`, `conda update`, and `conda create`."""
     newenv = command == "create"
     isupdate = command == "update"
@@ -389,7 +392,7 @@ def install(args, parser, command="install"):
                 command=args.cmd,
             )
             try:
-                unlink_link_transaction = solver.solve_for_transaction(
+                solved_diff = solver.solve_for_diff(
                     deps_modifier=deps_modifier,
                     update_modifier=update_modifier,
                     force_reinstall=context.force_reinstall or context.force,
@@ -401,7 +404,7 @@ def install(args, parser, command="install"):
                 if not getattr(e, "allow_retry", True):
                     raise e
                 if _should_retry_unfrozen:
-                    unlink_link_transaction = solver.solve_for_transaction(
+                    solved_diff = solver.solve_for_diff(
                         deps_modifier=deps_modifier,
                         update_modifier=UpdateModifier.UPDATE_SPECS,
                         force_reinstall=context.force_reinstall or context.force,
@@ -416,7 +419,7 @@ def install(args, parser, command="install"):
                     raise CondaImportError(str(e))
                 raise e
 
-    handle_txn(unlink_link_transaction, prefix, args, newenv)
+    await handle_txn_for_diff(solved_diff, prefix, args, newenv)
 
 
 def install_clone(args, parser):
@@ -566,3 +569,47 @@ def handle_txn(unlink_link_transaction, prefix, args, newenv, remove_op=False):
     if context.json:
         actions = unlink_link_transaction._make_legacy_action_groups()[0]
         common.stdout_json_success(prefix=prefix, actions=actions)
+
+
+async def handle_txn_for_diff(solved_diff, prefix, args, newenv, remove_op=False):
+    # Note:
+    # - benchmark with --json output
+    # - doesn't do dry run, or download only
+    if newenv:
+        if context.subdir != context._native_subdir():
+            set_keys(
+                ("subdir", context.subdir),
+                path=Path(prefix, DEFAULT_CONDARC_FILENAME),
+            )
+
+    prefix_data = PrefixData(prefix)
+    installed = [
+        PackageRecord(
+             name=rec.name, version=rec.version, build=rec.build,
+             build_number=rec.build_number, subdir=rec.subdir, arch=None,
+             platform=None
+        )
+        for rec in prefix_data.iter_records()
+    ]
+
+    records_repodata_records = []
+    for rec in solved_diff[1]:
+        pkg_rec = PackageRecord(
+             name=rec.name, version=rec.version, build=rec.build,
+             build_number=rec.build_number, subdir=rec.subdir, arch=None,
+             platform=None
+        )
+        records_repodata_records.append(RepoDataRecord(
+            package_record=pkg_rec,
+            file_name=rec.url.split("/")[-1],
+            channel=str(rec.channel),
+            url=rec.url
+        ))
+    
+    await rattler_install(
+        records = records_repodata_records,
+        target_prefix=prefix,
+        installed_packages=installed,
+    )
+
+    

--- a/conda/cli/main_create.py
+++ b/conda/cli/main_create.py
@@ -6,7 +6,7 @@ Creates new conda environments with the specified packages.
 """
 
 from __future__ import annotations
-
+import asyncio
 from logging import getLogger
 from typing import TYPE_CHECKING
 
@@ -167,7 +167,7 @@ def execute(args: Namespace, parser: ArgumentParser) -> int:
     if args.clone:
         install_clone(args, parser)
     else:
-        install(args, parser, "create")
+        asyncio.run(install(args, parser, "create"))
     # Run post-install steps applicable to all new environments
     prefix_data.set_nonadmin()
     print_activate(args.name or context.target_prefix)


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Use rattler to install packages (instead of conda bulit in transactions).

#### Some benchmarks with command `conda create python numpy scipy imagesize`

Using this PR, warmed up cache
```
 $ hyperfine 'python -m conda create -p /tmp/rattlerinstall-wc python numpy scipy imagesize --json --yes' --warmup 5
Benchmark 1: python -m conda create -p /tmp/rattlerinstall-wc python numpy scipy imagesize --json --yes
  Time (mean ± σ):      4.520 s ±  0.128 s    [User: 3.699 s, System: 1.502 s]
  Range (min … max):    4.320 s …  4.758 s    10 runs
```

Using this PR, cold cache
```
$ hyperfine 'python -m conda create -p /tmp/rattlerinstall-cc python numpy scipy imagesize --json --yes' -p 'rm -rf ~/.cache/rattler '
Benchmark 1: python -m conda create -p /tmp/rattlerinstall-cc python numpy scipy imagesize --json --yes
  Time (mean ± σ):     74.917 s ±  1.406 s    [User: 9.532 s, System: 4.980 s]
  Range (min … max):   73.475 s … 78.261 s    10 runs
```

On the main branch, warm cache
```
$ hyperfine 'python -m conda create -p /tmp/condainstall python numpy scipy imagesize --json --yes'
Benchmark 1: python -m conda create -p /tmp/condainstall python numpy scipy imagesize --json --yes
  Time (mean ± σ):      7.231 s ±  0.093 s    [User: 6.052 s, System: 1.266 s]
  Range (min … max):    7.101 s …  7.428 s    10 runs
```

On the main branch, cold cache
```
$ hyperfine 'python -m conda create -p /tmp/condainstall python numpy scipy imagesize --json --yes' -p 'conda clean --all --yes'
Benchmark 1: python -m conda create -p /tmp/condainstall python numpy scipy imagesize --json --yes
  Time (mean ± σ):     66.399 s ±  1.815 s    [User: 16.974 s, System: 3.447 s]
  Range (min … max):   64.342 s … 69.503 s    10 runs
```

#### Some benchmarks with command `conda create  python numpy scipy imagesize matplotlib pandas scikit-learn`

Using this PR, warmed up cache
```
$ hyperfine 'python -m conda create -p /tmp/rattlerinstall python numpy scipy imagesize matplotlib pandas scikit-learn --json --yes' --warmup 1 
Benchmark 1: python -m conda create -p /tmp/condainstall python numpy scipy imagesize matplotlib pandas scikit-learn --json --yes
  Time (mean ± σ):      6.471 s ±  0.480 s    [User: 5.266 s, System: 3.125 s]
  Range (min … max):    5.702 s …  7.453 s    10 runs

```

On the main branch, warm cache
```
$ hyperfine 'python -m conda create -p /tmp/condainstall python numpy scipy imagesize matplotlib pandas scikit-learn --json --yes' --warmup 1 
Benchmark 1: python -m conda create -p /tmp/condainstall python numpy scipy imagesize matplotlib pandas scikit-learn --json --yes
  Time (mean ± σ):     16.879 s ±  2.681 s    [User: 14.371 s, System: 2.508 s]
  Range (min … max):   14.827 s … 22.959 s    10 runs
```
